### PR TITLE
Make render strategy client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Make render strategy `client`, i.e. component assets are fetched client-side with same priority as server-side blocks.
+
 ## [0.2.1] - 2019-08-29
 
 ## [0.2.0] - 2019-08-14

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,6 +1,6 @@
 {
   "locale-switcher": {
     "component": "LocaleSwitcher",
-    "render": "lazy"
+    "render": "client"
   }
 }


### PR DESCRIPTION
Make assets subject to asset bundling and therefore load faster, instead of waiting for asset discovery during tree hydration.

Lazy is supposed to be used for components that might not be rendered.