### PR TITLE
Fix supported languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix supported locales
 
 ## [0.2.2] - 2019-09-10
 

--- a/react/package.json
+++ b/react/package.json
@@ -27,6 +27,6 @@
     "eslint-config-vtex": "^10.1.0",
     "prettier": "^1.16.4",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.3.4000"
+    "typescript": "3.5.2"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5022,10 +5022,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 typescript@^3.3.3333:
   version "3.4.3"


### PR DESCRIPTION
`spaziolusso` account was showing supported locales in the wrong way. There was a prioritization for the `en`, `pt` and `es` locales. As `spaziolusso` has `it` as its default language, the logic broke.

Before: The site text is shown in italian and  the default locale text is `en`

![image](https://user-images.githubusercontent.com/19555647/65454364-5bf86700-de1b-11e9-8714-22325de35566.png)

After: The site text is shown in italian and the default locale text is `it`

![image](https://user-images.githubusercontent.com/19555647/65454475-9235e680-de1b-11e9-8b5c-7326ba5eefe3.png)

The fix was also tested in `storecomponents` and no side effects were observed. 