### PR TITLE
Add check for null currentBinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing handling for `null` `currentBinding`.
 
 ## [0.5.2] - 2020-02-12
 ### Fixed

--- a/react/LocaleSwitcher.tsx
+++ b/react/LocaleSwitcher.tsx
@@ -66,7 +66,7 @@ const LocaleSwitcher = () => {
   const [openLocaleSelector, setOpenLocaleSelector] = useState(false)
 
   const supportedLanguages =
-    data?.currentBinding?.supportedLocales ?? data?.languages.supported ?? []
+    data?.currentBinding?.supportedLocales ?? data?.languages?.supported ?? []
   const supportedLangs = getSupportedLangs(supportedLanguages)
 
   const [selectedLocale, setSelectedLocale] = useState(() =>

--- a/react/LocaleSwitcher.tsx
+++ b/react/LocaleSwitcher.tsx
@@ -22,7 +22,7 @@ interface LocalesQuery {
   }
   currentBinding: {
     supportedLocales: string[]
-  }
+  } | null
 }
 
 interface SupportedLanguage {
@@ -66,7 +66,7 @@ const LocaleSwitcher = () => {
   const [openLocaleSelector, setOpenLocaleSelector] = useState(false)
 
   const supportedLanguages =
-    data?.currentBinding.supportedLocales ?? data?.languages.supported ?? []
+    data?.currentBinding?.supportedLocales ?? data?.languages.supported ?? []
   const supportedLangs = getSupportedLangs(supportedLanguages)
 
   const [selectedLocale, setSelectedLocale] = useState(() =>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a conditional check to handle the case when `currentBinding` is `null`.

#### What problem is this solving?

`currentBinding` query might return `null` and that was not taken into account.

#### How should this be manually tested?

https://localeswitcher--storecomponents.myvtex.com/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
