### PR TITLE
Fix popover position when wrapper is a child of a flex container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A wrapper for the locale switcher to prevent the container from growing if the parent is `flex` and a `relativeContainer` handle.
 
 ## [0.5.3] - 2020-02-12
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,11 +33,12 @@ The VTEX LocaleSwitcher is a VTEX component capable of changing the current lang
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles    |
-| -------------- |
-| `buttonText`   |
-| `button`       |
-| `listElement`  |
-| `list`         |
-| `localeIdText` |
-| `container`    |
+| CSS Handles         |
+| ------------------- |
+| `button`            |
+| `buttonText`        |
+| `container`         |
+| `list`              |
+| `listElement`       |
+| `localeIdText`      |
+| `relativeContainer` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "locale-switcher",
-  "license": "UNLICENSED",
   "private": true,
+  "license": "UNLICENSED",
   "scripts": {
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "format": "prettier --write \"**/*.{ts,js,json}\""
@@ -28,6 +28,7 @@
     "husky": "^4.2.0",
     "lint-staged": "^10.0.2",
     "prettier": "^1.19.1",
+    "react": "^16.12.0",
     "typescript": "^3.7.5"
   }
 }

--- a/react/.prettierrc
+++ b/react/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "jsxBracketSameLine": true
-}

--- a/react/LocaleSwitcher.tsx
+++ b/react/LocaleSwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, FC } from 'react'
 import { useQuery } from 'react-apollo'
 import { useRuntime } from 'vtex.render-runtime'
 import { IconGlobe } from 'vtex.store-icons'
@@ -8,6 +8,7 @@ import Locales from './graphql/locales.gql'
 
 const CSS_HANDLES = [
   'container',
+  'relativeContainer',
   'button',
   'buttonText',
   'list',
@@ -60,7 +61,7 @@ function getSupportedLangs(langs: string[]) {
   }, [])
 }
 
-const LocaleSwitcher = () => {
+const LocaleSwitcher: FC = () => {
   const { data, loading, error } = useQuery<LocalesQuery>(Locales)
   const { culture, emitter } = useRuntime()
   const [openLocaleSelector, setOpenLocaleSelector] = useState(false)
@@ -92,30 +93,34 @@ const LocaleSwitcher = () => {
 
   return (
     <div className={containerClasses}>
-      <button
-        className={buttonClasses}
-        onBlur={() => setOpenLocaleSelector(false)}
-        onClick={() => setOpenLocaleSelector(!openLocaleSelector)}>
-        <IconGlobe />
-        <span className={buttonTextClasses}>{selectedLocale.text}</span>
-      </button>
-      <ul hidden={!openLocaleSelector} className={listClasses}>
-        {supportedLangs
-          .filter(({ localeId }) => localeId !== selectedLocale.localeId)
-          .map(({ localeId, text }) => (
-            <li key={localeId} className={listElementClasses}>
-              <span
-                role="link"
-                tabIndex={-1}
-                className={`${handles.localeIdText} w-100`}
-                onMouseDown={e => e.preventDefault()}
-                onClick={() => handleLocaleClick(localeId)}
-                onKeyDown={() => handleLocaleClick(localeId)}>
-                {text}
-              </span>
-            </li>
-          ))}
-      </ul>
+      <div className={`${handles.relativeContainer} relative`}>
+        <button
+          className={buttonClasses}
+          onBlur={() => setOpenLocaleSelector(false)}
+          onClick={() => setOpenLocaleSelector(!openLocaleSelector)}
+        >
+          <IconGlobe />
+          <span className={buttonTextClasses}>{selectedLocale.text}</span>
+        </button>
+        <ul hidden={!openLocaleSelector} className={listClasses}>
+          {supportedLangs
+            .filter(({ localeId }) => localeId !== selectedLocale.localeId)
+            .map(({ localeId, text }) => (
+              <li key={localeId} className={listElementClasses}>
+                <span
+                  role="link"
+                  tabIndex={-1}
+                  className={`${handles.localeIdText} w-100`}
+                  onMouseDown={e => e.preventDefault()}
+                  onClick={() => handleLocaleClick(localeId)}
+                  onKeyDown={() => handleLocaleClick(localeId)}
+                >
+                  {text}
+                </span>
+              </li>
+            ))}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,7 +1321,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1687,7 +1687,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -1713,6 +1713,15 @@ react-is@^16.8.1:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
+  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the position of the locale switcher popover when the parent is a `flex` container and  bigger than expected. 

This solution is the same used in [vtex-login](https://github.com/vtex-apps/login/blob/master/react/components/LoginComponent.js#L145)

#### What problem is this solving?

If the current locale switcher is located inside a bigger-than-expected flex container, the popover position gets messed up (see screenshot). 

#### How should this be manually tested?

1) https://kiwi--storecomponents.myvtex.com/

#### Screenshots or example usage

Without the fix:
![image](https://user-images.githubusercontent.com/12702016/74474545-80b1b180-4e84-11ea-856c-82378ded2cab.png)

With the fix:
![image](https://user-images.githubusercontent.com/12702016/74475617-88725580-4e86-11ea-866e-326a171e40f0.png)


#### Alternatives

It's possible to fix the error from the screenshot by using a `flex-layout.col` instead of using the `locale-switcher` as a direct child of a `flex-layout.row`. However, it's more verbose and adds a bit of unnecessary logic and elements to the layout.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
