### PR TITLE
Make the LocaleSwitcher lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Loading state when the query is being made.
+
+### Changed
+- Make the query of supported languages only when the user interacts with the `LocaleSwitcher`.
 
 ## [0.5.4] - 2020-02-13
 ### Added

--- a/react/LocaleSwitcher.tsx
+++ b/react/LocaleSwitcher.tsx
@@ -1,54 +1,39 @@
-import React, { useState, FC } from 'react'
-import { useQuery } from 'react-apollo'
-import { useRuntime } from 'vtex.render-runtime'
+import React, { useState } from 'react'
 import { IconGlobe } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime, Culture } from 'vtex.render-runtime'
+import { Spinner } from 'vtex.styleguide'
 
-import Locales from './graphql/locales.gql'
+import LocaleSwitcherList from './components/LocaleSwitcherList'
 
 const CSS_HANDLES = [
-  'container',
-  'relativeContainer',
-  'button',
-  'buttonText',
   'list',
+  'button',
+  'container',
+  'buttonText',
   'listElement',
   'localeIdText',
-]
+  'loadingContainer',
+  'relativeContainer',
+] as const
 
-interface LocalesQuery {
-  languages: {
-    default: string
-    supported: string[]
-  }
-  currentBinding: {
-    supportedLocales: string[]
-  } | null
-}
-
-interface SupportedLanguage {
+export interface SupportedLanguage {
   text: string
   localeId: string
 }
 
-function getLabel(localeId: string) {
+export function getLabel(localeId: string) {
   return localeId.split('-')[0]
 }
 
-function getLocale(supportedLangs: SupportedLanguage[], locale: string) {
-  const localeObj = supportedLangs.find(
-    ({ localeId }) => getLabel(localeId) === getLabel(locale)
-  )
-  return (
-    localeObj ??
-    (supportedLangs?.[0] || {
-      text: getLabel(locale),
-      localeId: locale,
-    })
-  )
+function parseToSupportedLang({ language, locale }: Culture) {
+  return {
+    text: getLabel(language),
+    localeId: locale,
+  }
 }
 
-function getSupportedLangs(langs: string[]) {
+export function getSupportedLangs(langs: string[]) {
   return langs.reduce((acc: SupportedLanguage[], lang: string) => {
     if (!lang.includes('-')) {
       return acc
@@ -61,65 +46,60 @@ function getSupportedLangs(langs: string[]) {
   }, [])
 }
 
-const LocaleSwitcher: FC = () => {
-  const { data, loading, error } = useQuery<LocalesQuery>(Locales)
+const LocaleSwitcher: React.FC = () => {
   const { culture, emitter } = useRuntime()
-  const [openLocaleSelector, setOpenLocaleSelector] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [shouldRenderList, setShouldRenderList] = useState(false)
+  const [changingLocale, setChangingLocale] = useState(false)
 
-  const supportedLanguages =
-    data?.currentBinding?.supportedLocales ?? data?.languages?.supported ?? []
-  const supportedLangs = getSupportedLangs(supportedLanguages)
-
-  const [selectedLocale, setSelectedLocale] = useState(() =>
-    getLocale(supportedLangs, culture?.locale)
+  const [selectedLocale, setSelectedLocale] = useState(
+    parseToSupportedLang(culture)
   )
   const handles = useCssHandles(CSS_HANDLES)
 
-  const handleLocaleClick = (id: SupportedLanguage['localeId']) => {
-    setOpenLocaleSelector(false)
-    setSelectedLocale(getLocale(supportedLangs, id))
-    emitter.emit('localesChanged', id)
+  const handleLocaleClick = (newLang: SupportedLanguage) => {
+    setSelectedLocale(newLang)
+    emitter.emit('localesChanged', newLang.localeId)
+    setChangingLocale(true)
+    setOpen(false)
   }
 
-  if (loading || error || supportedLangs.length === 0) {
-    return null
+  const handleClick = () => {
+    setOpen(!open)
+
+    if (!shouldRenderList) {
+      setShouldRenderList(true)
+    }
   }
 
   const containerClasses = `${handles.container} w3 flex items-center justify-end ml2 mr3 relative`
   const buttonClasses = `${handles.button} link pa0 bg-transparent bn flex items-center pointer mr3 c-on-base`
   const buttonTextClasses = `${handles.buttonText} pl2 t-action--small order-1`
-  const listClasses = `${handles.list} absolute z-5 list top-1 w3 ph0 mh0 mt4 bg-base`
-  const listElementClasses = `${handles.listElement} t-action--small pointer f5 pa3 hover-bg-muted-5 tc`
 
   return (
     <div className={containerClasses}>
       <div className={`${handles.relativeContainer} relative`}>
         <button
+          onClick={handleClick}
           className={buttonClasses}
-          onBlur={() => setOpenLocaleSelector(false)}
-          onClick={() => setOpenLocaleSelector(!openLocaleSelector)}
+          onBlur={() => setOpen(false)}
         >
-          <IconGlobe />
-          <span className={buttonTextClasses}>{selectedLocale.text}</span>
+          {!changingLocale ? (
+            <>
+              <IconGlobe />
+              <span className={buttonTextClasses}>{selectedLocale.text}</span>
+            </>
+          ) : (
+            <Spinner handles={handles} size={26} />
+          )}
         </button>
-        <ul hidden={!openLocaleSelector} className={listClasses}>
-          {supportedLangs
-            .filter(({ localeId }) => localeId !== selectedLocale.localeId)
-            .map(({ localeId, text }) => (
-              <li key={localeId} className={listElementClasses}>
-                <span
-                  role="link"
-                  tabIndex={-1}
-                  className={`${handles.localeIdText} w-100`}
-                  onMouseDown={e => e.preventDefault()}
-                  onClick={() => handleLocaleClick(localeId)}
-                  onKeyDown={() => handleLocaleClick(localeId)}
-                >
-                  {text}
-                </span>
-              </li>
-            ))}
-        </ul>
+        {shouldRenderList && (
+          <LocaleSwitcherList
+            open={open}
+            onItemClick={handleLocaleClick}
+            selectedLocale={selectedLocale}
+          />
+        )}
       </div>
     </div>
   )

--- a/react/LocaleSwitcher.tsx
+++ b/react/LocaleSwitcher.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react'
+import { Spinner } from 'vtex.styleguide'
+import { SupportedLanguage } from 'langs'
 import { IconGlobe } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 import { useRuntime, Culture } from 'vtex.render-runtime'
-import { Spinner } from 'vtex.styleguide'
 
+import getLabel from './modules/getLabel'
 import LocaleSwitcherList from './components/LocaleSwitcherList'
 
 const CSS_HANDLES = [
@@ -17,33 +19,11 @@ const CSS_HANDLES = [
   'relativeContainer',
 ] as const
 
-export interface SupportedLanguage {
-  text: string
-  localeId: string
-}
-
-export function getLabel(localeId: string) {
-  return localeId.split('-')[0]
-}
-
 function parseToSupportedLang({ language, locale }: Culture) {
   return {
     text: getLabel(language),
     localeId: locale,
   }
-}
-
-export function getSupportedLangs(langs: string[]) {
-  return langs.reduce((acc: SupportedLanguage[], lang: string) => {
-    if (!lang.includes('-')) {
-      return acc
-    }
-
-    return acc.concat({
-      text: getLabel(lang),
-      localeId: lang,
-    })
-  }, [])
 }
 
 const LocaleSwitcher: React.FC = () => {

--- a/react/components/LocaleSwitcherList.tsx
+++ b/react/components/LocaleSwitcherList.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { useQuery } from 'react-apollo'
+import { useCssHandles } from 'vtex.css-handles'
+
+import Spinner from './Spinner'
+import LOCALES from '../graphql/locales.gql'
+import {
+  getLabel,
+  SupportedLanguage,
+  getSupportedLangs,
+} from '../LocaleSwitcher'
+
+interface Props {
+  open?: boolean
+  selectedLocale: SupportedLanguage
+  onItemClick: (selectedLang: SupportedLanguage) => void
+}
+
+interface LocalesQuery {
+  languages: {
+    default: string
+    supported: string[]
+  }
+  currentBinding: {
+    supportedLocales: string[]
+  } | null
+}
+
+function getLocale(supportedLangs: SupportedLanguage[], locale: string) {
+  const localeObj = supportedLangs.find(
+    ({ localeId }) => getLabel(localeId) === getLabel(locale)
+  )
+
+  return (
+    localeObj ??
+    (supportedLangs?.[0] || {
+      text: getLabel(locale),
+      localeId: locale,
+    })
+  )
+}
+
+const CSS_HANDLES = [
+  'list',
+  'listElement',
+  'localeIdText',
+  'loadingContainer',
+] as const
+
+export default function LocaleSwitcherList(props: Props) {
+  const { open = false, onItemClick, selectedLocale } = props
+  const handles = useCssHandles(CSS_HANDLES)
+  const { data, loading, error } = useQuery<LocalesQuery>(LOCALES)
+
+  const supportedLanguages =
+    data?.currentBinding?.supportedLocales ?? data?.languages?.supported ?? []
+  const supportedLangs = getSupportedLangs(supportedLanguages)
+
+  if (loading && open) {
+    return <Spinner handles={handles} />
+  }
+
+  if (error || supportedLangs.length === 0) {
+    return null
+  }
+
+  const handleItemClick = (id: SupportedLanguage['localeId']) => {
+    onItemClick(getLocale(supportedLangs, id))
+  }
+
+  const listClasses = `${handles.list} absolute z-5 list top-1 w3 ph0 mh0 mt4 bg-base`
+  const listElementClasses = `${handles.listElement} t-action--small pointer f5 pa3 hover-bg-muted-5 tc`
+
+  return (
+    <ul hidden={!open} className={listClasses}>
+      {supportedLangs
+        .filter(({ localeId }) => localeId !== selectedLocale.localeId)
+        .map(({ localeId, text }) => (
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+          <li
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+            role="link"
+            tabIndex={-1}
+            key={localeId}
+            className={listElementClasses}
+            onClick={() => handleItemClick(localeId)}
+            onKeyDown={() => handleItemClick(localeId)}
+            onMouseDown={e => e.preventDefault()}
+          >
+            <span className={`${handles.localeIdText} w-100`}>{text}</span>
+          </li>
+        ))}
+    </ul>
+  )
+}

--- a/react/components/LocaleSwitcherList.tsx
+++ b/react/components/LocaleSwitcherList.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 import { useQuery } from 'react-apollo'
+import { SupportedLanguage } from 'langs'
 import { useCssHandles } from 'vtex.css-handles'
 
 import Spinner from './Spinner'
+import getLabel from '../modules/getLabel'
 import LOCALES from '../graphql/locales.gql'
-import {
-  getLabel,
-  SupportedLanguage,
-  getSupportedLangs,
-} from '../LocaleSwitcher'
+import getSupportedLangs from '../modules/getSupportedLangs'
 
 interface Props {
   open?: boolean

--- a/react/components/Spinner.tsx
+++ b/react/components/Spinner.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Spinner } from 'vtex.styleguide'
+import classnames from 'classnames'
+
+interface Props {
+  handles: Record<string, string>
+}
+
+export default function Loading(props: Props) {
+  const { handles } = props
+
+  const classes = classnames(
+    handles.loadingContainer,
+    'absolute z-5 list top-1 pa6 mh0 mt4 bg-base flex items-center justify-center'
+  )
+
+  return (
+    <div className={classes}>
+      <Spinner color="currentColor" size={26} />
+    </div>
+  )
+}

--- a/react/modules/getLabel.ts
+++ b/react/modules/getLabel.ts
@@ -1,0 +1,3 @@
+export default function getLabel(localeId: string) {
+  return localeId.split('-')[0]
+}

--- a/react/modules/getSupportedLangs.ts
+++ b/react/modules/getSupportedLangs.ts
@@ -1,0 +1,16 @@
+import { SupportedLanguage } from 'langs'
+
+import getLabel from './getLabel'
+
+export default function getSupportedLangs(langs: string[]) {
+  return langs.reduce((acc: SupportedLanguage[], lang: string) => {
+    if (!lang.includes('-')) {
+      return acc
+    }
+
+    return acc.concat({
+      text: getLabel(lang),
+      localeId: lang,
+    })
+  }, [])
+}

--- a/react/package.json
+++ b/react/package.json
@@ -23,7 +23,7 @@
     "@vtex/test-tools": "^0.2.0",
     "apollo-client": "^2.5.1",
     "prettier": "^1.16.4",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "version": "0.5.4"
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -15,6 +15,6 @@
   "typeAcquisition": {
     "enable": false
   },
-  "include": ["./typings/*.d.ts", "./**/*.tsx"],
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/react/typings/langs.d.ts
+++ b/react/typings/langs.d.ts
@@ -1,0 +1,6 @@
+declare module 'langs' {
+  export interface SupportedLanguage {
+    text: string
+    localeId: string
+  }
+}

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,5 @@
+declare module 'vtex.css-handles' {
+  export function useCssHandles<ClassKey extends string = string>(
+    handles: readonly ClassKey[]
+  ): Record<ClassKey, string>
+}

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -26,6 +26,19 @@ declare module 'vtex.render-runtime' {
     id: string
   }
 
+  export interface Culture {
+    availableLocales: string[]
+    locale: string
+    language: string
+    country: string
+    currency: string
+  }
+
+  interface RenderContext {
+    culture: Culture
+    emitter: any
+  }
+
   export const ChildBlock: ComponentType<ChildBlockProps>
   export const useChildBlock = function({ id: string }): object {}
 
@@ -34,7 +47,7 @@ declare module 'vtex.render-runtime' {
   export const NoSSR: ReactElement
   export const RenderContextConsumer: ReactElement
   export const canUseDOM: boolean
-  export const useRuntime: any
+  export const useRuntime: () => RenderContext
   export const withRuntimeContext: <TOriginalProps extends {}>(
     Component: ComponentType<TOriginalProps & RenderContextProps>
   ) => ComponentType<TOriginalProps>

--- a/react/typings/vtex.store-icons.d.ts
+++ b/react/typings/vtex.store-icons.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.store-icons' {
+  export const IconGlobe: React.FC
+}

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -2,9 +2,10 @@
 declare module 'vtex.styleguide' {
   import { ComponentType } from 'react'
 
-  export const Input: ComponentType<InputProps>
+  export const Input: ComponentType<Props>
+  export const Spinner: ComponentType<Props>
 
-  interface InputProps {
+  interface Props {
     [key: string]: any
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4444,10 +4444,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.7.5"


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Make the query of supported languages only when the user interacts with the `LocaleSwitcher`.

#### How should this be manually tested?

1. Go to the [workspace](https://localeperformance--storecomponents.myvtex.com/)
2. Open the dev tool on `network`
3. Click on the locale switcher, you should see a loading state and see that the query is being made just after you clicked

#### Screenshots or example usage
Before
![image](https://user-images.githubusercontent.com/8517023/76344686-be1d2980-62e0-11ea-8514-59f2251aca5d.png)
After
![image](https://user-images.githubusercontent.com/8517023/76344698-c2e1dd80-62e0-11ea-9a47-3ddf7d019a4b.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
